### PR TITLE
Replace log with enabled_log in azurerm_monitor_diagnostic_setting due to deprecation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 ---
 variables:
   TF_MIN_VERSION: "1.1"
-  AZURERM_PROVIDER_MIN_VERSION: "3.22"
+  AZURERM_PROVIDER_MIN_VERSION: "3.39.0"
 
 include:
   - template: 'Workflows/Branch-Pipelines.gitlab-ci.yml'

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module "diagnostic_settings" {
 | Name | Version |
 |------|---------|
 | azurecaf | ~> 1.2, >= 1.2.22 |
-| azurerm | ~> 3.22 |
+| azurerm | ~> 3.39 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module "diagnostic_settings" {
 | Name | Version |
 |------|---------|
 | azurecaf | ~> 1.2, >= 1.2.22 |
-| azurerm | ~>3.39 |
+| azurerm | ~>3.39.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ module "diagnostic_settings" {
 
 ## Providers
 
-| Name     | Version           |
-| -------- | ----------------- |
+| Name | Version |
+|------|---------|
 | azurecaf | ~> 1.2, >= 1.2.22 |
-| azurerm  | ~> 3.22           |
+| azurerm | ~> 3.22 |
 
 ## Modules
 
@@ -143,32 +143,32 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                                           | Type        |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [azurerm_monitor_diagnostic_setting.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting)          | resource    |
-| [azurecaf_name.diag](https://registry.terraform.io/providers/aztfmod/azurecaf/latest/docs/data-sources/name)                                                   | data source |
+| Name | Type |
+|------|------|
+| [azurerm_monitor_diagnostic_setting.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurecaf_name.diag](https://registry.terraform.io/providers/aztfmod/azurecaf/latest/docs/data-sources/name) | data source |
 | [azurerm_monitor_diagnostic_categories.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_diagnostic_categories) | data source |
 
 ## Inputs
 
-| Name                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                       | Type           | Default              | Required |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------- | :------: |
-| custom\_name                      | Name of the diagnostic settings, generated if empty.                                                                                                                                                                                                                                                                                                                                                                                              | `string`       | `""`                 |    no    |
-| excluded\_log\_categories         | List of log categories to exclude.                                                                                                                                                                                                                                                                                                                                                                                                                | `list(string)` | `[]`                 |    no    |
-| log\_analytics\_destination\_type | When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.                                                                                                                                                                                                                                                                                               | `string`       | `"AzureDiagnostics"` |    no    |
-| log\_categories                   | List of log categories. Defaults to all available.                                                                                                                                                                                                                                                                                                                                                                                                | `list(string)` | `null`               |    no    |
-| logs\_destinations\_ids           | List of destination resources IDs for logs diagnostic destination.<br>Can be `Storage Account`, `Log Analytics Workspace` and `Event Hub`. No more than one of each can be set.<br>If you want to use Azure EventHub as destination, you must provide a formatted string with both the EventHub Namespace authorization send ID and the EventHub name (name of the queue to use in the Namespace) separated by the <code>&#124;</code> character. | `list(string)` | n/a                  |   yes    |
-| metric\_categories                | List of metric categories. Defaults to all available.                                                                                                                                                                                                                                                                                                                                                                                             | `list(string)` | `null`               |    no    |
-| name\_prefix                      | Optional prefix for the generated name                                                                                                                                                                                                                                                                                                                                                                                                            | `string`       | `""`                 |    no    |
-| name\_suffix                      | Optional suffix for the generated name                                                                                                                                                                                                                                                                                                                                                                                                            | `string`       | `""`                 |    no    |
-| resource\_id                      | The ID of the resource on which activate the diagnostic settings.                                                                                                                                                                                                                                                                                                                                                                                 | `string`       | n/a                  |   yes    |
-| retention\_days                   | The number of days to keep diagnostic logs.                                                                                                                                                                                                                                                                                                                                                                                                       | `number`       | `30`                 |    no    |
-| use\_caf\_naming                  | Use the Azure CAF naming provider to generate default resource name. `custom_name` override this if set. Legacy default name is used if this is set to `false`.                                                                                                                                                                                                                                                                                   | `bool`         | `true`               |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| custom\_name | Name of the diagnostic settings, generated if empty. | `string` | `""` | no |
+| excluded\_log\_categories | List of log categories to exclude. | `list(string)` | `[]` | no |
+| log\_analytics\_destination\_type | When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table. | `string` | `"AzureDiagnostics"` | no |
+| log\_categories | List of log categories. Defaults to all available. | `list(string)` | `null` | no |
+| logs\_destinations\_ids | List of destination resources IDs for logs diagnostic destination.<br>Can be `Storage Account`, `Log Analytics Workspace` and `Event Hub`. No more than one of each can be set.<br>If you want to use Azure EventHub as destination, you must provide a formatted string with both the EventHub Namespace authorization send ID and the EventHub name (name of the queue to use in the Namespace) separated by the <code>&#124;</code> character. | `list(string)` | n/a | yes |
+| metric\_categories | List of metric categories. Defaults to all available. | `list(string)` | `null` | no |
+| name\_prefix | Optional prefix for the generated name | `string` | `""` | no |
+| name\_suffix | Optional suffix for the generated name | `string` | `""` | no |
+| resource\_id | The ID of the resource on which activate the diagnostic settings. | `string` | n/a | yes |
+| retention\_days | The number of days to keep diagnostic logs. | `number` | `30` | no |
+| use\_caf\_naming | Use the Azure CAF naming provider to generate default resource name. `custom_name` override this if set. Legacy default name is used if this is set to `false`. | `bool` | `true` | no |
 
 ## Outputs
 
-| Name                     | Description                    |
-| ------------------------ | ------------------------------ |
+| Name | Description |
+|------|-------------|
 | diagnostic\_settings\_id | ID of the Diagnostic Settings. |
 <!-- END_TF_DOCS -->
 ## Related documentation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Azure Diagnostic Settings
-
 [![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![Apache V2 License](https://img.shields.io/badge/license-Apache%20V2-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/claranet/diagnostic-settings/azurerm/)
 
 This module is based on work from [Innovation Norway](https://github.com/InnovationNorway/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Azure Diagnostic Settings
+
 [![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![Apache V2 License](https://img.shields.io/badge/license-Apache%20V2-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/claranet/diagnostic-settings/azurerm/)
 
 This module is based on work from [Innovation Norway](https://github.com/InnovationNorway/).
@@ -132,10 +133,10 @@ module "diagnostic_settings" {
 
 ## Providers
 
-| Name | Version |
-|------|---------|
+| Name     | Version           |
+| -------- | ----------------- |
 | azurecaf | ~> 1.2, >= 1.2.22 |
-| azurerm | ~> 3.22 |
+| azurerm  | ~> 3.22           |
 
 ## Modules
 
@@ -143,32 +144,32 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [azurerm_monitor_diagnostic_setting.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurecaf_name.diag](https://registry.terraform.io/providers/aztfmod/azurecaf/latest/docs/data-sources/name) | data source |
+| Name                                                                                                                                                           | Type        |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [azurerm_monitor_diagnostic_setting.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting)          | resource    |
+| [azurecaf_name.diag](https://registry.terraform.io/providers/aztfmod/azurecaf/latest/docs/data-sources/name)                                                   | data source |
 | [azurerm_monitor_diagnostic_categories.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_diagnostic_categories) | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| custom\_name | Name of the diagnostic settings, generated if empty. | `string` | `""` | no |
-| excluded\_log\_categories | List of log categories to exclude. | `list(string)` | `[]` | no |
-| log\_analytics\_destination\_type | When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table. | `string` | `"AzureDiagnostics"` | no |
-| log\_categories | List of log categories. Defaults to all available. | `list(string)` | `null` | no |
-| logs\_destinations\_ids | List of destination resources IDs for logs diagnostic destination.<br>Can be `Storage Account`, `Log Analytics Workspace` and `Event Hub`. No more than one of each can be set.<br>If you want to use Azure EventHub as destination, you must provide a formatted string with both the EventHub Namespace authorization send ID and the EventHub name (name of the queue to use in the Namespace) separated by the <code>&#124;</code> character. | `list(string)` | n/a | yes |
-| metric\_categories | List of metric categories. Defaults to all available. | `list(string)` | `null` | no |
-| name\_prefix | Optional prefix for the generated name | `string` | `""` | no |
-| name\_suffix | Optional suffix for the generated name | `string` | `""` | no |
-| resource\_id | The ID of the resource on which activate the diagnostic settings. | `string` | n/a | yes |
-| retention\_days | The number of days to keep diagnostic logs. | `number` | `30` | no |
-| use\_caf\_naming | Use the Azure CAF naming provider to generate default resource name. `custom_name` override this if set. Legacy default name is used if this is set to `false`. | `bool` | `true` | no |
+| Name                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                       | Type           | Default              | Required |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------- | :------: |
+| custom\_name                      | Name of the diagnostic settings, generated if empty.                                                                                                                                                                                                                                                                                                                                                                                              | `string`       | `""`                 |    no    |
+| excluded\_log\_categories         | List of log categories to exclude.                                                                                                                                                                                                                                                                                                                                                                                                                | `list(string)` | `[]`                 |    no    |
+| log\_analytics\_destination\_type | When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.                                                                                                                                                                                                                                                                                               | `string`       | `"AzureDiagnostics"` |    no    |
+| log\_categories                   | List of log categories. Defaults to all available.                                                                                                                                                                                                                                                                                                                                                                                                | `list(string)` | `null`               |    no    |
+| logs\_destinations\_ids           | List of destination resources IDs for logs diagnostic destination.<br>Can be `Storage Account`, `Log Analytics Workspace` and `Event Hub`. No more than one of each can be set.<br>If you want to use Azure EventHub as destination, you must provide a formatted string with both the EventHub Namespace authorization send ID and the EventHub name (name of the queue to use in the Namespace) separated by the <code>&#124;</code> character. | `list(string)` | n/a                  |   yes    |
+| metric\_categories                | List of metric categories. Defaults to all available.                                                                                                                                                                                                                                                                                                                                                                                             | `list(string)` | `null`               |    no    |
+| name\_prefix                      | Optional prefix for the generated name                                                                                                                                                                                                                                                                                                                                                                                                            | `string`       | `""`                 |    no    |
+| name\_suffix                      | Optional suffix for the generated name                                                                                                                                                                                                                                                                                                                                                                                                            | `string`       | `""`                 |    no    |
+| resource\_id                      | The ID of the resource on which activate the diagnostic settings.                                                                                                                                                                                                                                                                                                                                                                                 | `string`       | n/a                  |   yes    |
+| retention\_days                   | The number of days to keep diagnostic logs.                                                                                                                                                                                                                                                                                                                                                                                                       | `number`       | `30`                 |    no    |
+| use\_caf\_naming                  | Use the Azure CAF naming provider to generate default resource name. `custom_name` override this if set. Legacy default name is used if this is set to `false`.                                                                                                                                                                                                                                                                                   | `bool`         | `true`               |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
+| Name                     | Description                    |
+| ------------------------ | ------------------------------ |
 | diagnostic\_settings\_id | ID of the Diagnostic Settings. |
 <!-- END_TF_DOCS -->
 ## Related documentation

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module "diagnostic_settings" {
 | Name | Version |
 |------|---------|
 | azurecaf | ~> 1.2, >= 1.2.22 |
-| azurerm | ~> 3.39 |
+| azurerm | ~>3.39 |
 
 ## Modules
 

--- a/examples/main/main.tf
+++ b/examples/main/main.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.1"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.0.0"
+      version = "~>3.39"
     }
   }
 }

--- a/examples/main/main.tf
+++ b/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.39"
+      version = "~>3.39.0"
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -19,6 +19,7 @@ locals {
 
   logs = {
     for category in try(data.azurerm_monitor_diagnostic_categories.main[0].log_category_types, []) : category => {
+      enabled        = contains(local.log_categories, category)
       retention_days = var.retention_days
     }
   }

--- a/locals.tf
+++ b/locals.tf
@@ -19,7 +19,6 @@ locals {
 
   logs = {
     for category in try(data.azurerm_monitor_diagnostic_categories.main[0].log_category_types, []) : category => {
-      enabled        = contains(local.log_categories, category)
       retention_days = var.retention_days
     }
   }

--- a/r-diagnostic.tf
+++ b/r-diagnostic.tf
@@ -17,7 +17,7 @@ resource "azurerm_monitor_diagnostic_setting" "main" {
   eventhub_name                  = local.eventhub_name
 
   dynamic "enabled_log" {
-    for_each = local.logs
+    for_each = ([for log in local.logs : log if log.value.enabled])
 
     content {
       category = enabled_log.key

--- a/r-diagnostic.tf
+++ b/r-diagnostic.tf
@@ -17,7 +17,7 @@ resource "azurerm_monitor_diagnostic_setting" "main" {
   eventhub_name                  = local.eventhub_name
 
   dynamic "enabled_log" {
-    for_each = ([for log in local.logs : log if log.value.enabled])
+    for_each = [for log in local.logs : log if log.value.enabled]
 
     content {
       category = enabled_log.key

--- a/r-diagnostic.tf
+++ b/r-diagnostic.tf
@@ -16,16 +16,15 @@ resource "azurerm_monitor_diagnostic_setting" "main" {
   eventhub_authorization_rule_id = local.eventhub_authorization_rule_id
   eventhub_name                  = local.eventhub_name
 
-  dynamic "log" {
+  dynamic "enabled_log" {
     for_each = local.logs
 
     content {
-      category = log.key
-      enabled  = log.value.enabled
+      category = enabled_log.key
 
       retention_policy {
-        enabled = log.value.enabled && log.value.retention_days != null
-        days    = log.value.enabled ? log.value.retention_days : 0
+        enabled = enabled_log.value.retention_days != null
+        days    = enabled_log.value.retention_days
       }
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.39"
+      version = "~>3.39.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39"
+      version = "~>3.39"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.39"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"


### PR DESCRIPTION
Fixes #(issue) .

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting#log
` log is deprecated in favour of the enabled_log property and will be removed in version 4.0 of the AzureRM Provider.`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Changes proposed in this pull request

- Replace log with enabled_log in azurerm_monitor_diagnostic_setting

@claranet/fr-azure-reviewers
